### PR TITLE
add gettext to fix build error

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -492,7 +492,7 @@ parts:
     organize:
       snap/corebird/current/usr: usr
     build-packages:
-			- gettext
+      - gettext
       - libjson-glib-dev
       - libsoup2.4-dev
       - libsqlite3-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -492,6 +492,7 @@ parts:
     organize:
       snap/corebird/current/usr: usr
     build-packages:
+			- gettext
       - libjson-glib-dev
       - libsoup2.4-dev
       - libsqlite3-dev


### PR DESCRIPTION
build service fails on missing msgfmt program. This PR adds gettext as a build-package to supply it appropriately.