### PR TITLE
fix path to screenshot in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ distributions.</p>
 
 ([Don't have snapd installed?](https://snapcraft.io/docs/core/install))
 
-![Corebird](assets/screenshot.png?raw=true "Corebird")
+![Corebird](snapcrafters-assets/screenshot.png?raw=true "Corebird")
 
 <p align="center">Published for <img src="http://anything.codes/slack-emoji-for-techies/emoji/tux.png" align="top" width="24" /> with :gift_heart: by Snapcrafters</p>
 


### PR DESCRIPTION
Screenshot moved from assets/ to snapcrafters-assets/. Fix the path in the readme to match.