### PR TITLE
links in last release fail to launch browser

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ plugs:
 apps:
   corebird:
     command: |
-      desktop-launch pulse-launch libopenh264-launch gstreamer-launch fontconfig-launch snapcraft-preload $SNAP/usr/bin/corebird
+      desktop-launch pulse-launch libopenh264-launch gstreamer-launch fontconfig-launch $SNAP/usr/bin/corebird
     plugs:
       - desktop
       - gsettings
@@ -644,7 +644,6 @@ parts:
       - gstreamer
       # - gstreamer-vaapi
       - pango
-      - snapcraft-preload
     plugin: autotools
     source: https://github.com/baedert/corebird/releases/download/1.7.1/corebird-1.7.1.tar.xz
     # for some reason building from git is failing due to the gst heck in the configure script


### PR DESCRIPTION
ref: sergiusens/snapcraft-preload#22

the snapcraft preload library intercepts the xdg-open calls causing link clicks to be silently ignored