### PR TITLE
fix build failures from 17 may

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -63,9 +63,7 @@ parts:
       gstreamer-launch: bin/gstreamer-launch
       pulse-launch: bin/pulse-launch
     prime:
-    - bin/fontconfig-launch
-    - bin/gstreamer-launch
-    - bin/pulse-launch
+    - bin/*-launch
     build-attributes: [no-system-libraries]
 
   alsa:
@@ -83,9 +81,9 @@ parts:
     prime:
     - bin/bunzip2
     - bin/libopenh264-launch
+    - lib
     - usr/bin/curl
     - usr/lib
-    - usr/share/locale
     build-attributes: [no-system-libraries]
 
   libopenh264-library:
@@ -143,8 +141,9 @@ parts:
     prime:
     - lib
     - usr/lib
-    - -usr/lib/**/include
+    - -usr/lib/pkgconfig
     - usr/libexec/gstreamer-1.0/gst-plugin-scanner
+    - usr/share/gir-1.0
     - usr/share/locale
     build-attributes: [no-system-libraries]
 
@@ -174,7 +173,7 @@ parts:
     prime:
     - lib
     - usr/lib
-    - -usr/lib/**/include
+    - -usr/lib/pkgconfig
     - usr/share/locale
     build-attributes: [no-system-libraries]
 
@@ -213,7 +212,6 @@ parts:
     - lib
     - usr/lib
     - -usr/lib/**/include
-    - usr/share/locale
     build-attributes: [no-system-libraries]
 
   gst-plugins-good:
@@ -294,7 +292,6 @@ parts:
     prime:
     - lib
     - usr/lib
-    - -usr/lib/**/include
     - usr/share/locale
     build-attributes: [no-system-libraries]
 
@@ -469,7 +466,8 @@ parts:
     prime:
     - lib
     - usr/lib
-    - -usr/lib/**/include
+    - -usr/lib/pkgconfig
+    - usr/share/gir-1.0
     - usr/share/locale
     build-attributes: [no-system-libraries]
 
@@ -499,7 +497,7 @@ parts:
       sed -i "s|/usr/lib|$SNAPCRAFT_STAGE/usr/lib|" $SNAPCRAFT_PART_INSTALL/usr/lib/pkgconfig/harfbuzz.pc
     prime:
     - usr/lib
-    - usr/share/locale
+    - -usr/lib/pkgconfig
     build-attributes: [no-system-libraries]
 
   freetype:
@@ -520,9 +518,9 @@ parts:
       sed -i "s|/usr/include|$SNAPCRAFT_STAGE/usr/include|" $SNAPCRAFT_PART_INSTALL/usr/lib/pkgconfig/freetype2.pc
       sed -i "s|/usr/lib|$SNAPCRAFT_STAGE/usr/lib|" $SNAPCRAFT_PART_INSTALL/usr/lib/pkgconfig/freetype2.pc
     prime:
-    - etc/fonts
+    - usr/bin
     - usr/lib
-    - usr/share/locale
+    - -usr/lib/pkgconfig
     build-attributes: [no-system-libraries]
 
   fontconfig:
@@ -545,8 +543,8 @@ parts:
     - etc/fonts
     - usr/bin/fc-*
     - usr/lib
+    - -usr/lib/pkgconfig
     - usr/share/fontconfig
-    - usr/share/locale
     build-attributes: [no-system-libraries]
 
   cairo:
@@ -570,7 +568,7 @@ parts:
         sed -i "s|/usr/include|$SNAPCRAFT_STAGE/usr/include|g;s|/usr/lib|$SNAPCRAFT_STAGE/usr/lib|g" '{}' \;
     prime:
     - usr/lib
-    - usr/share/locale
+    - -usr/lib/pkgconfig
     build-attributes: [no-system-libraries]
 
   pango:
@@ -594,7 +592,8 @@ parts:
         sed -i "s|/usr/include|$SNAPCRAFT_STAGE/usr/include|g;s|/usr/lib|$SNAPCRAFT_STAGE/usr/lib|g" '{}' \;
     prime:
     - usr/lib
-    - usr/share/locale
+    - -usr/lib/pkgconfig
+    - usr/share/gir-1.0
     build-attributes: [no-system-libraries]
 
   corebird:
@@ -628,7 +627,6 @@ parts:
     - valac
     prime:
     - usr/bin/corebird
-    - usr/lib
     - usr/share/applications/org.baedert.corebird.desktop
     - usr/share/dbus-1/services/org.baedert.corebird.service
     - usr/share/glib-2.0/schemas/org.baedert.corebird.gschema.xml


### PR DESCRIPTION
removes elements from `prime:` that won't exist during build, causing failure
fixes #29